### PR TITLE
FEAT: Colorful help

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,7 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 name = "join-ai"
 version = "0.1.0"
 dependencies = [
+ "anstyle",
  "anyhow",
  "assert_fs",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "A tool to traverse files in a folder and concatenate them into a 
 
 [dependencies]
 anyhow = "1.0.99"
-clap = { version = "4.5.45", features = ["derive"] }
+clap = { version = "4.5.45", features = ["derive", "color"] }
 content_inspector = "0.2.4"
 ignore = "0.4.23"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2024"
 description = "A tool to traverse files in a folder and concatenate them into a single text file for GenAI models."
 
 [dependencies]
+anstyle = "1.0.11"
 anyhow = "1.0.99"
 clap = { version = "4.5.45", features = ["derive", "color"] }
 content_inspector = "0.2.4"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 /// A CLI application to traverse files in a folder and concatenate them
 /// into a single text file, suitable for GenAI model input.
 #[derive(Parser, Debug, Clone)]
-#[command(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None, color = clap::ColorChoice::Always)]
 pub struct Args {
     /// The input folder to traverse for files
     #[arg(required = true)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,10 +1,10 @@
-use clap::Parser;
+use clap::{ColorChoice, Parser};
 use std::path::PathBuf;
 
 /// A CLI application to traverse files in a folder and concatenate them
 /// into a single text file, suitable for GenAI model input.
 #[derive(Parser, Debug, Clone)]
-#[command(author, version, about, long_about = None, color = clap::ColorChoice::Always)]
+#[command(author, version, about, long_about = None, color = ColorChoice::Always)]
 pub struct Args {
     /// The input folder to traverse for files
     #[arg(required = true)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,33 @@
-use clap::Parser;
+use anstyle::{AnsiColor, Color, Style};
+use clap::builder::styling::Styles;
+use clap::{CommandFactory, FromArgMatches};
 use join_ai::{cli::Args, run};
 
+// Function to create the cargo-like styles
+fn get_styles() -> Styles {
+    Styles::styled()
+        .header(
+            Style::new()
+                .fg_color(Some(Color::Ansi(AnsiColor::Green)))
+                .bold(),
+        )
+        .usage(
+            Style::new()
+                .fg_color(Some(Color::Ansi(AnsiColor::Green)))
+                .bold(),
+        )
+        .literal(
+            Style::new()
+                .fg_color(Some(Color::Ansi(AnsiColor::Cyan)))
+                .bold(),
+        )
+        .placeholder(Style::new().fg_color(Some(Color::Ansi(AnsiColor::Cyan))))
+}
+
 fn main() -> anyhow::Result<()> {
-    let args = Args::parse();
+    let mut cmd = Args::command();
+    cmd = cmd.styles(get_styles());
+    let matches = cmd.get_matches();
+    let args = Args::from_arg_matches(&matches)?;
     run(args)
 }


### PR DESCRIPTION
Color the output from `join-ai --help`, following the colors used in `cargo --help`