### PR TITLE
FEAT: Unify file exclusion using glob patterns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,15 +151,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
-name = "content_inspector"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,7 +275,6 @@ dependencies = [
  "anyhow",
  "assert_fs",
  "clap",
- "content_inspector",
  "ignore",
  "tempfile",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ description = "A tool to traverse files in a folder and concatenate them into a 
 anstyle = "1.0.11"
 anyhow = "1.0.99"
 clap = { version = "4.5.45", features = ["derive", "color"] }
-content_inspector = "0.2.4"
 ignore = "0.4.23"
 
 [dev-dependencies]

--- a/install.sh
+++ b/install.sh
@@ -53,7 +53,7 @@ find_install_dir() {
         echo "$HOME/bin"
         return
     fi
-    
+
     # Fallback to system-wide directory (might require sudo)
     if [ -d "/usr/local/bin" ] && [ -w "/usr/local/bin" ]; then
         echo "/usr/local/bin"
@@ -75,7 +75,7 @@ main() {
     echo "Latest version: $LATEST_TAG"
 
     DOWNLOAD_URL="https://github.com/$REPO/releases/download/$LATEST_TAG/$BINARY_NAME-$TARGET"
-    
+
     # Create a temporary directory for the download
     TMP_DIR=$(mktemp -d)
     # Ensure the temporary directory is cleaned up on exit

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,19 @@
 use std::fs;
 
+// Public modules that make up the library's functionality.
 pub mod cli;
 pub mod processor;
 pub mod walker;
 
 use cli::{Commands, JoinArgs};
 
-/// The core logic of the application.
+/// The primary entry point for the library's logic.
+/// It takes a parsed `Commands` enum and dispatches to the appropriate handler.
 pub fn run(command: Commands) -> anyhow::Result<()> {
     match command {
         Commands::Join(args) => run_join(args),
         Commands::Update(_args) => {
+            // Placeholder for future update functionality.
             println!("Update functionality is not yet implemented.");
             println!("Please check for new releases at the GitHub repository:");
             println!("https://github.com/luizvbo/join-ai/releases");
@@ -19,9 +22,10 @@ pub fn run(command: Commands) -> anyhow::Result<()> {
     }
 }
 
-/// The logic for the 'join' command.
+/// Handles the logic for the 'join' command.
+/// This function orchestrates the file finding and processing steps.
 fn run_join(args: JoinArgs) -> anyhow::Result<()> {
-    // Log the arguments being used
+    // --- 1. Log the configuration for user feedback ---
     println!(
         "Processing files in folder: {}",
         args.input_folder.display()
@@ -31,14 +35,11 @@ fn run_join(args: JoinArgs) -> anyhow::Result<()> {
     } else {
         println!("Using patterns: all files");
     }
-    if let Some(exclude_folders) = &args.exclude_folders {
-        println!("Excluding folders: {}", exclude_folders.join(", "));
-    }
-    if let Some(exclude_extensions) = &args.exclude_extensions {
-        println!("Excluding extensions: {}", exclude_extensions.join(", "));
+    if let Some(exclude_patterns) = &args.exclude {
+        println!("Excluding patterns: {}", exclude_patterns.join(", "));
     }
 
-    // Clear the output file if specified
+    // --- 2. Prepare the output file ---
     if args.clear_file && args.output_file.exists() {
         fs::remove_file(&args.output_file)?;
         println!(
@@ -47,10 +48,12 @@ fn run_join(args: JoinArgs) -> anyhow::Result<()> {
         );
     }
 
-    // 1. Find all relevant files using the walker module
+    // --- 3. Find all relevant files using the walker module ---
+    // The walker runs in a background thread and sends file paths via a channel.
     let receiver = walker::find_files(&args)?;
 
-    // 2. Process the files found by the walker
+    // --- 4. Process the files found by the walker ---
+    // The processor reads each file and appends its content to the output file.
     processor::process_files(receiver, &args.output_file)?;
 
     println!(
@@ -61,6 +64,7 @@ fn run_join(args: JoinArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
+// --- Integration-style Tests for Core Logic ---
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -70,29 +74,28 @@ mod tests {
     use std::fs::{self};
     use std::path::Path;
 
-    /// Helper to create a standard JoinArgs struct for tests.
+    /// Test helper to create a standard `JoinArgs` struct with common defaults.
     fn get_test_args(input_folder: &Path, output_file: &Path) -> JoinArgs {
         JoinArgs {
             input_folder: input_folder.to_path_buf(),
             output_file: output_file.to_path_buf(),
             patterns: None,
-            clear_file: false, // Default to false to test clearing explicitly
-            exclude_folders: None,
-            exclude_extensions: None,
+            exclude: None,
+            clear_file: false,
             max_depth: None,
             hidden: false,
             no_follow: true,
         }
     }
 
-    /// Helper to run the join command and read the resulting output file.
+    /// Test helper to execute the `run_join` command and return the content of the output file.
     fn run_join_and_read_output(args: JoinArgs) -> anyhow::Result<String> {
         let output_path = args.output_file.clone();
         run(Commands::Join(args))?;
-        // Use fs::read_to_string for simplicity if the file might not be created.
         Ok(fs::read_to_string(output_path).unwrap_or_default())
     }
 
+    /// Verifies that only files matching the include patterns are processed.
     #[test]
     fn test_filter_by_multiple_patterns() -> anyhow::Result<()> {
         let dir = TempDir::new()?;
@@ -114,6 +117,7 @@ mod tests {
         Ok(())
     }
 
+    /// Verifies that binary files (containing NUL bytes) are automatically skipped.
     #[test]
     fn test_skip_binary_files() -> anyhow::Result<()> {
         let dir = TempDir::new()?;
@@ -132,46 +136,7 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_exclude_folders() -> anyhow::Result<()> {
-        let dir = TempDir::new()?;
-        dir.child("src/main.rs").write_str("main")?;
-        dir.child("target/debug/app").write_str("binary")?;
-        dir.child("docs/guide.md").write_str("guide")?;
-
-        let output_file = dir.path().join("output.txt");
-        let mut args = get_test_args(dir.path(), &output_file);
-        args.exclude_folders = Some(vec!["target".to_string(), "docs".to_string()]);
-
-        let result = run_join_and_read_output(args)?;
-
-        assert!(result.contains("main.rs"));
-        assert!(!result.contains("app"));
-        assert!(!result.contains("guide.md"));
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_exclude_extensions() -> anyhow::Result<()> {
-        let dir = TempDir::new()?;
-        dir.child("code.rs").write_str("main")?;
-        dir.child("notes.txt").write_str("notes")?;
-        dir.child("log.log").write_str("log")?;
-
-        let output_file = dir.path().join("output.txt");
-        let mut args = get_test_args(dir.path(), &output_file);
-        args.exclude_extensions = Some(vec!["log".to_string(), "txt".to_string()]);
-
-        let result = run_join_and_read_output(args)?;
-
-        assert!(result.contains("code.rs"));
-        assert!(!result.contains("notes.txt"));
-        assert!(!result.contains("log.log"));
-
-        Ok(())
-    }
-
+    /// Verifies that the `--max-depth` argument correctly limits traversal.
     #[test]
     fn test_max_depth() -> anyhow::Result<()> {
         let dir = TempDir::new()?;
@@ -181,7 +146,7 @@ mod tests {
 
         let output_file = dir.path().join("output.txt");
         let mut args = get_test_args(dir.path(), &output_file);
-        args.max_depth = Some(2); // Root (depth 0), level1 (depth 1), level2 (depth 2)
+        args.max_depth = Some(2);
 
         let result = run_join_and_read_output(args)?;
 
@@ -192,6 +157,7 @@ mod tests {
         Ok(())
     }
 
+    /// Verifies that hidden files are ignored by default.
     #[test]
     fn test_hidden_files_are_skipped_by_default() -> anyhow::Result<()> {
         let dir = TempDir::new()?;
@@ -209,6 +175,7 @@ mod tests {
         Ok(())
     }
 
+    /// Verifies that the `--hidden` flag includes hidden files in the output.
     #[test]
     fn test_hidden_files_are_included_with_flag() -> anyhow::Result<()> {
         let dir = TempDir::new()?;
@@ -227,24 +194,24 @@ mod tests {
         Ok(())
     }
 
+    /// Verifies that the application does not read and include its own output file.
     #[test]
     fn test_output_file_is_skipped() -> anyhow::Result<()> {
         let dir = TempDir::new()?;
         let output_file = dir.path().join("output.txt");
-        // Create the output file beforehand to ensure it exists during the walk
         fs::write(&output_file, "initial content")?;
         dir.child("input.txt").write_str("input")?;
 
         let args = get_test_args(dir.path(), &output_file);
         let result = run_join_and_read_output(args)?;
 
-        // The result should not contain its own initial content
         assert!(!result.contains("initial content"));
         assert!(result.contains("input.txt"));
 
         Ok(())
     }
 
+    /// Verifies that the `--clear-file` flag deletes existing content before writing.
     #[test]
     fn test_clear_file_option() -> anyhow::Result<()> {
         let dir = TempDir::new()?;
@@ -263,6 +230,7 @@ mod tests {
         Ok(())
     }
 
+    /// Verifies that running on an empty directory produces an empty output file.
     #[test]
     fn test_empty_directory_produces_empty_file() -> anyhow::Result<()> {
         let dir = TempDir::new()?;
@@ -276,12 +244,119 @@ mod tests {
         Ok(())
     }
 
+    /// Verifies that the `update` command can be called without error.
     #[test]
     fn test_update_command_placeholder() -> anyhow::Result<()> {
-        // This test simply ensures the update command can be called without error.
-        // A more advanced test would capture stdout, but this is sufficient.
         let update_args = cli::UpdateArgs {};
         run(Commands::Update(update_args))?;
+        Ok(())
+    }
+
+    // --- New Tests for Exclude Functionality ---
+
+    /// Verifies that a folder pattern (e.g., "target/") excludes all its contents.
+    #[test]
+    fn test_exclude_by_folder_pattern() -> anyhow::Result<()> {
+        let dir = TempDir::new()?;
+        dir.child("src/main.rs").write_str("main")?;
+        dir.child("target/debug/app").write_str("binary")?;
+        dir.child("docs/guide.md").write_str("guide")?;
+
+        let output_file = dir.path().join("output.txt");
+        let mut args = get_test_args(dir.path(), &output_file);
+        args.exclude = Some(vec!["target/".to_string(), "docs/".to_string()]);
+
+        let result = run_join_and_read_output(args)?;
+
+        assert!(result.contains("main.rs"));
+        assert!(!result.contains("app"));
+        assert!(!result.contains("guide.md"));
+
+        Ok(())
+    }
+
+    /// Verifies that a file extension pattern (e.g., "*.log") excludes matching files.
+    #[test]
+    fn test_exclude_by_extension_pattern() -> anyhow::Result<()> {
+        let dir = TempDir::new()?;
+        dir.child("code.rs").write_str("main")?;
+        dir.child("notes.md").write_str("notes")?;
+        dir.child("log.log").write_str("log")?;
+
+        let output_file = dir.path().join("output.txt");
+        let mut args = get_test_args(dir.path(), &output_file);
+        args.exclude = Some(vec!["*.log".to_string(), "*.md".to_string()]);
+
+        let result = run_join_and_read_output(args)?;
+
+        assert!(result.contains("code.rs"));
+        assert!(!result.contains("notes.md"));
+        assert!(!result.contains("log.log"));
+
+        Ok(())
+    }
+
+    /// Verifies that multiple, different exclusion patterns work together.
+    #[test]
+    fn test_exclude_by_multiple_patterns() -> anyhow::Result<()> {
+        let dir = TempDir::new()?;
+        dir.child("src/main.rs").write_str("main")?;
+        dir.child("src/error.log").write_str("log")?;
+        dir.child("target/app").write_str("binary")?;
+
+        let output_file = dir.path().join("output.txt");
+        let mut args = get_test_args(dir.path(), &output_file);
+        args.exclude = Some(vec!["target/".to_string(), "*.log".to_string()]);
+
+        let result = run_join_and_read_output(args)?;
+
+        assert!(result.contains("main.rs"));
+        assert!(!result.contains("error.log"));
+        assert!(!result.contains("app"));
+
+        Ok(())
+    }
+
+    /// Verifies that an exclude pattern will override an include pattern.
+    #[test]
+    fn test_exclude_takes_precedence_over_include() -> anyhow::Result<()> {
+        let dir = TempDir::new()?;
+        dir.child("src/main.rs").write_str("main")?;
+        dir.child("src/lib.rs").write_str("lib")?;
+        dir.child("tests/integration_test.rs").write_str("test")?;
+
+        let output_file = dir.path().join("output.txt");
+        let mut args = get_test_args(dir.path(), &output_file);
+        args.patterns = Some(vec!["*.rs".to_string()]); // Include all .rs files
+        args.exclude = Some(vec!["tests/".to_string()]); // But exclude the tests folder
+
+        let result = run_join_and_read_output(args)?;
+
+        assert!(result.contains("main.rs"));
+        assert!(result.contains("lib.rs"));
+        assert!(!result.contains("integration_test.rs"));
+
+        Ok(())
+    }
+
+    /// Verifies that a specific file can be excluded by its full path relative to the input.
+    #[test]
+    fn test_exclude_specific_file() -> anyhow::Result<()> {
+        let dir = TempDir::new()?;
+        dir.child("src/main.rs").write_str("main")?;
+        dir.child("src/config.rs").write_str("config")?;
+        dir.child("README.md").write_str("readme")?;
+
+        let output_file = dir.path().join("output.txt");
+        let mut args = get_test_args(dir.path(), &output_file);
+        args.exclude = Some(vec!["src/config.rs".to_string()]);
+
+        let result = run_join_and_read_output(args)?;
+
+        assert!(result.contains("main.rs"));
+        assert!(result.contains("README.md"));
+        assert!(!result.contains("config.rs"));
+
         Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,8 @@ use clap::builder::styling::Styles;
 use clap::{CommandFactory, FromArgMatches};
 use join_ai::{cli::Cli, run};
 
-// Function to create the cargo-like styles
+/// Creates a custom style for the CLI's help output, mimicking the appearance of `cargo`.
+/// This provides a more professional and familiar feel for Rust developers.
 fn get_styles() -> Styles {
     Styles::styled()
         .header(
@@ -24,10 +25,20 @@ fn get_styles() -> Styles {
         .placeholder(Style::new().fg_color(Some(Color::Ansi(AnsiColor::Cyan))))
 }
 
+/// The main entry point of the application binary.
 fn main() -> anyhow::Result<()> {
+    // 1. Build the command-line interface definition from the `Cli` struct.
     let mut cmd = Cli::command();
+
+    // 2. Apply the custom styles to the command's help message.
     cmd = cmd.styles(get_styles());
+
+    // 3. Parse the actual command-line arguments provided by the user.
     let matches = cmd.get_matches();
+
+    // 4. Convert the parsed matches back into our strongly-typed `Cli` struct.
     let cli = Cli::from_arg_matches(&matches)?;
+
+    // 5. Pass the parsed command to the core logic in the `lib.rs` crate.
     run(cli.command)
 }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -3,29 +3,43 @@ use std::io::{self, Write};
 use std::path::PathBuf;
 use std::sync::mpsc;
 
-/// Processes file paths received from a channel, concatenating their content into an output file.
+/// This module handles the processing of files. It receives file paths from the
+/// walker, reads their content, and writes it to the final output file.
+
+/// Processes file paths received from a channel, concatenating their content.
+///
+/// # Arguments
+/// * `rx` - The receiver end of a channel, which provides `PathBuf`s from the walker.
+/// * `output_file_path` - The path to the file where content should be written.
 pub fn process_files(
     rx: mpsc::Receiver<PathBuf>,
     output_file_path: &PathBuf,
 ) -> anyhow::Result<()> {
+    // Create or truncate the output file, making it ready for writing.
     let mut output_file = File::create(output_file_path)?;
 
+    // Iterate over every file path sent by the walker.
+    // This loop will block until the channel is empty and the sender is dropped.
     for path in rx {
         match fs::read(&path) {
             Ok(contents) => {
-                // A robust way to detect binary files is to check for the NUL byte.
+                // A simple and robust way to detect binary files is to check for the NUL byte,
+                // which is common in compiled files but rare in text files.
                 if contents.contains(&0) {
                     println!("Skipping binary file: {}", path.display());
-                    continue;
+                    continue; // Skip to the next file.
                 }
 
-                // Write the header and file content
+                // Write a header comment to delineate files in the concatenated output.
                 writeln!(output_file, "// FILE: {}", path.display())?;
+                // Write the actual content of the file.
                 output_file.write_all(&contents)?;
+                // Add a newline for spacing between files.
                 writeln!(output_file)?;
             }
             Err(e) => {
-                // Ignore errors from special files that can't be read (e.g., pipes)
+                // It's possible to encounter files that can't be read (e.g., system pipes,
+                // broken symlinks). We log these errors but don't stop the process.
                 if e.kind() != io::ErrorKind::InvalidData {
                     eprintln!("Failed to read file {}: {}", path.display(), e);
                 }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -5,8 +5,6 @@ use std::sync::mpsc;
 
 /// This module handles the processing of files. It receives file paths from the
 /// walker, reads their content, and writes it to the final output file.
-
-/// Processes file paths received from a channel, concatenating their content.
 ///
 /// # Arguments
 /// * `rx` - The receiver end of a channel, which provides `PathBuf`s from the walker.

--- a/src/walker.rs
+++ b/src/walker.rs
@@ -3,75 +3,96 @@ use ignore::{WalkBuilder, WalkState};
 use std::path::PathBuf;
 use std::sync::mpsc;
 
-/// Sets up and runs the file walker, sending valid file paths through a channel.
+/// This module is responsible for efficiently finding all files that match the
+/// user's criteria using the `ignore` crate, which is excellent at respecting
+/// rules like `.gitignore` and handling parallel directory traversal.
+
+/// Sets up and executes the file walker.
+///
+/// The walker runs in a separate thread pool and sends valid file paths back to the
+/// main thread through a multi-producer, single-consumer (mpsc) channel.
+///
+/// # Arguments
+/// * `args` - A reference to the parsed `JoinArgs` containing all CLI options.
+///
+/// # Returns
+/// A `Result` containing the receiver end of the channel, which will be used by
+/// the processor to receive file paths.
 pub fn find_files(args: &JoinArgs) -> anyhow::Result<mpsc::Receiver<PathBuf>> {
+    // Create a channel for communication between the walker threads and the main thread.
     let (tx, rx) = mpsc::channel();
     let input_folder = args.input_folder.clone();
 
+    // --- 1. Configure the base walker ---
     let mut walker_builder = WalkBuilder::new(&input_folder);
-    // REMOVED: .hidden(!args.hidden) -> This will be handled by the overrides below.
     walker_builder
         .follow_links(!args.no_follow)
         .max_depth(args.max_depth);
 
+    // --- 2. Build a set of override rules for inclusion and exclusion ---
+    // The `OverrideBuilder` allows us to programmatically add glob patterns that
+    // take precedence over any `.gitignore` or similar rules.
     let mut override_builder = ignore::overrides::OverrideBuilder::new(&input_folder);
 
+    // Add inclusion patterns. If none are provided, default to including everything.
     if let Some(patterns) = &args.patterns {
         for pattern in patterns {
             override_builder.add(pattern)?;
         }
     } else {
-        override_builder.add("*")?; // Default to including all files if no pattern is given
+        // A single "*" will match all files, which is a good default.
+        override_builder.add("*")?;
     }
 
-    // ADDED: If hidden files are not requested, explicitly add a glob to ignore them.
-    // This is needed because the "*" override above would otherwise include them.
+    // Add all exclusion patterns. These are prefixed with "!" to negate the match.
+    if let Some(exclude_patterns) = &args.exclude {
+        for pattern in exclude_patterns {
+            let exclusion_pattern = format!("!{}", pattern);
+            override_builder.add(&exclusion_pattern)?;
+        }
+    }
+
+    // If hidden files are not requested, add a global ignore pattern for them.
+    // This is necessary because the `*` override would otherwise include them.
     if !args.hidden {
         override_builder.add("!.*")?;
     }
 
-    if let Some(exclude_folders) = &args.exclude_folders {
-        for folder in exclude_folders {
-            // The "!" prefix negates the pattern, effectively excluding it.
-            override_builder.add(&format!("!{}", folder))?;
-        }
-    }
-
+    // Apply the built override rules to the walker.
     let overrides = override_builder.build()?;
     walker_builder.overrides(overrides);
 
+    // --- 3. Run the walker in parallel ---
     let walker = walker_builder.build_parallel();
     let output_file_path = args.output_file.clone();
-    let exclude_extensions = args.exclude_extensions.clone();
 
-    // The walker runs in a separate thread pool
+    // The `run` method spawns a thread pool to perform the walk.
+    // We provide a closure that builds a "move closure" for each thread.
     walker.run(move || {
+        // Clone the transmitter and other necessary data for each thread.
         let tx = tx.clone();
-        let exclude_extensions = exclude_extensions.clone();
         let output_file_path = output_file_path.clone();
 
+        // This inner closure is executed for each directory entry found.
         Box::new(move |result| {
             if let Ok(entry) = result {
                 let path = entry.path();
-                // Skip directories and the output file itself
+                // Skip directories and the application's own output file.
                 if path.is_dir() || path == output_file_path {
                     return WalkState::Continue;
                 }
 
-                // Filter by extension
-                if let Some(ext_str) = path.extension().and_then(|s| s.to_str())
-                    && let Some(exts_to_exclude) = &exclude_extensions
-                    && exts_to_exclude.contains(&ext_str.to_string())
-                {
-                    return WalkState::Continue;
-                }
+                // All filtering is now handled by the `overrides`, so we don't
+                // need to manually check extensions or folders here.
 
-                // If all checks pass, send the path for processing
+                // If all checks pass, send the valid file path to the processor.
                 tx.send(path.to_path_buf()).expect("Failed to send path");
             }
+            // Continue the walk regardless of the result.
             WalkState::Continue
         })
     });
 
+    // Return the receiver end of the channel to the caller.
     Ok(rx)
 }

--- a/src/walker.rs
+++ b/src/walker.rs
@@ -6,8 +6,6 @@ use std::sync::mpsc;
 /// This module is responsible for efficiently finding all files that match the
 /// user's criteria using the `ignore` crate, which is excellent at respecting
 /// rules like `.gitignore` and handling parallel directory traversal.
-
-/// Sets up and executes the file walker.
 ///
 /// The walker runs in a separate thread pool and sends valid file paths back to the
 /// main thread through a multi-producer, single-consumer (mpsc) channel.
@@ -47,7 +45,7 @@ pub fn find_files(args: &JoinArgs) -> anyhow::Result<mpsc::Receiver<PathBuf>> {
     // Add all exclusion patterns. These are prefixed with "!" to negate the match.
     if let Some(exclude_patterns) = &args.exclude {
         for pattern in exclude_patterns {
-            let exclusion_pattern = format!("!{}", pattern);
+            let exclusion_pattern = format!("!{pattern}");
             override_builder.add(&exclusion_pattern)?;
         }
     }


### PR DESCRIPTION
This commit refactors the file exclusion mechanism, enhancing flexibility and reducing dependencies.

The `content_inspector` crate has been removed. Binary file detection now relies on a simpler and more direct NUL byte check within the file content, which is sufficient for its purpose and eliminates an external dependency.

A new, unified `--exclude` (`-x`) CLI argument has been introduced. This argument accepts glob patterns, allowing users to specify both files and folders to exclude from the traversal. This replaces the previously separate and less flexible `--exclude-folders` and `--exclude-extensions` arguments, which have been removed.

This change leverages the `ignore` crate's `OverrideBuilder` to provide a more powerful and consistent filtering mechanism, enabling the definition of complex inclusion and exclusion rules with a single, intuitive argument.

Additionally, CLI argument descriptions, internal code comments, and the test suite have been updated to reflect these changes and improve overall clarity and maintainability.