### PR TITLE
FEAT: Add Verbose Output (`-v`, `-vv`)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -59,6 +59,10 @@ pub struct JoinArgs {
     /// If set to false, the walker will follow symbolic links. Defaults to true (no-follow).
     #[arg(long, default_value_t = true)]
     pub no_follow: bool,
+
+    /// Enable verbose output. Use -v for basic info, -vv for detailed debugging.
+    #[arg(short, long, action = clap::ArgAction::Count)]
+    pub verbose: u8,
 }
 
 /// Defines the arguments for the 'update' subcommand. Currently a placeholder.
@@ -89,6 +93,7 @@ mod tests {
                 assert!(join_args.exclude.is_none());
                 assert!(join_args.max_depth.is_none());
                 assert!(join_args.no_follow); // Default is true
+                assert_eq!(join_args.verbose, 0);
             }
             _ => panic!("Expected Join command to be parsed"),
         }
@@ -116,6 +121,7 @@ mod tests {
             "--max-depth",
             "10",
             "--hidden",
+            "-vv",
         ];
         let cli = Cli::try_parse_from(args).unwrap();
 
@@ -135,6 +141,7 @@ mod tests {
                 assert_eq!(join_args.max_depth, Some(10));
                 assert!(join_args.hidden);
                 assert!(join_args.no_follow);
+                assert_eq!(join_args.verbose, 2);
             }
             _ => panic!("Expected Join command to be parsed"),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ fn run_join(args: JoinArgs) -> anyhow::Result<()> {
 
     // --- 4. Process the files found by the walker ---
     // The processor reads each file and appends its content to the output file.
-    processor::process_files(receiver, &args.output_file)?;
+    processor::process_files(receiver, &args.output_file, args.verbose)?;
 
     println!(
         "Files have been processed and written to {}",
@@ -85,6 +85,7 @@ mod tests {
             max_depth: None,
             hidden: false,
             no_follow: true,
+            verbose: 0,
         }
     }
 

--- a/src/walker.rs
+++ b/src/walker.rs
@@ -17,80 +17,122 @@ use std::sync::mpsc;
 /// A `Result` containing the receiver end of the channel, which will be used by
 /// the processor to receive file paths.
 pub fn find_files(args: &JoinArgs) -> anyhow::Result<mpsc::Receiver<PathBuf>> {
-    // Create a channel for communication between the walker threads and the main thread.
-    let (tx, rx) = mpsc::channel();
     let input_folder = args.input_folder.clone();
 
-    // --- 1. Configure the base walker ---
-    let mut walker_builder = WalkBuilder::new(&input_folder);
-    walker_builder
-        .follow_links(!args.no_follow)
-        .max_depth(args.max_depth);
-
-    // --- 2. Build a set of override rules for inclusion and exclusion ---
-    // The `OverrideBuilder` allows us to programmatically add glob patterns that
-    // take precedence over any `.gitignore` or similar rules.
+    // --- 1. Build a set of override rules for inclusion and exclusion ---
     let mut override_builder = ignore::overrides::OverrideBuilder::new(&input_folder);
-
-    // Add inclusion patterns. If none are provided, default to including everything.
     if let Some(patterns) = &args.patterns {
         for pattern in patterns {
             override_builder.add(pattern)?;
         }
     } else {
-        // A single "*" will match all files, which is a good default.
         override_builder.add("*")?;
     }
-
-    // Add all exclusion patterns. These are prefixed with "!" to negate the match.
     if let Some(exclude_patterns) = &args.exclude {
         for pattern in exclude_patterns {
             let exclusion_pattern = format!("!{pattern}");
             override_builder.add(&exclusion_pattern)?;
         }
     }
-
-    // If hidden files are not requested, add a global ignore pattern for them.
-    // This is necessary because the `*` override would otherwise include them.
     if !args.hidden {
         override_builder.add("!.*")?;
     }
-
-    // Apply the built override rules to the walker.
     let overrides = override_builder.build()?;
-    walker_builder.overrides(overrides);
 
-    // --- 3. Run the walker in parallel ---
+    // --- 2. If verbosity is >= 2, run a diagnostic walk ---
+    if args.verbose > 1 {
+        println!("\n[Verbose Mode] Analyzing file matches...");
+        let debug_walker = WalkBuilder::new(&input_folder)
+            .follow_links(!args.no_follow)
+            .max_depth(args.max_depth)
+            .hidden(!args.hidden) // Walker's hidden(true) means "ignore hidden"
+            .build();
+
+        for result in debug_walker {
+            let entry = match result {
+                Ok(entry) => entry,
+                Err(e) => {
+                    eprintln!("[Verbose Mode] Error: {}", e);
+                    continue;
+                }
+            };
+            let path = entry.path();
+            if path.is_dir() {
+                continue;
+            }
+            if path == args.output_file {
+                println!(
+                    "- {:<10} {} (is the output file)",
+                    "Skipped",
+                    path.display()
+                );
+                continue;
+            }
+
+            match overrides.matched(path, false) {
+                ignore::Match::Whitelist(glob) => {
+                    println!(
+                        "+ {:<10} {} (matched include pattern: '{:?}')",
+                        "Included",
+                        path.display(),
+                        glob
+                    );
+                }
+                ignore::Match::Ignore(glob) => {
+                    println!(
+                        "- {:<10} {} (matched exclude pattern: '{:?}')",
+                        "Excluded",
+                        path.display(),
+                        glob
+                    );
+                }
+                ignore::Match::None => {
+                    // The walker already filters out files ignored by .gitignore etc.
+                    // So if we are here, the file was not ignored by standard rules.
+                    if args.patterns.is_some() {
+                        println!(
+                            "- {:<10} {} (did not match any include pattern)",
+                            "Excluded",
+                            path.display()
+                        );
+                    } else {
+                        println!(
+                            "+ {:<10} {} (included by default)",
+                            "Included",
+                            path.display()
+                        );
+                    }
+                }
+            }
+        }
+        println!("[Verbose Mode] Analysis complete.\n");
+    }
+
+    // --- 3. Run the main, parallel walker for actual processing ---
+    let (tx, rx) = mpsc::channel();
+    let mut walker_builder = WalkBuilder::new(&input_folder);
+    walker_builder
+        .follow_links(!args.no_follow)
+        .max_depth(args.max_depth);
+    walker_builder.overrides(overrides.clone()); // Use the same rules
+
     let walker = walker_builder.build_parallel();
     let output_file_path = args.output_file.clone();
 
-    // The `run` method spawns a thread pool to perform the walk.
-    // We provide a closure that builds a "move closure" for each thread.
     walker.run(move || {
-        // Clone the transmitter and other necessary data for each thread.
         let tx = tx.clone();
         let output_file_path = output_file_path.clone();
-
-        // This inner closure is executed for each directory entry found.
         Box::new(move |result| {
             if let Ok(entry) = result {
                 let path = entry.path();
-                // Skip directories and the application's own output file.
                 if path.is_dir() || path == output_file_path {
                     return WalkState::Continue;
                 }
-
-                // All filtering is now handled by the `overrides`, so we don't
-                // need to manually check extensions or folders here.
-
-                // If all checks pass, send the valid file path to the processor.
                 tx.send(path.to_path_buf()).expect("Failed to send path");
             }
-            // Continue the walk regardless of the result.
             WalkState::Continue
         })
     });
 
-    // Return the receiver end of the channel to the caller.
     Ok(rx)
 }


### PR DESCRIPTION
This PR adds a verbose mode to the `join` subcommand, giving users more control over the command's output. This new feature helps to debug file-matching issues by providing detailed information on which files are being processed and which are being skipped.

* **`cli.rs`**: Adds a new optional argument, `--verbose` or `-v`, to the `join` subcommand. The argument's value is a `u8` that can be incremented by using multiple flags (e.g., `-vv`).
* **`walker.rs`**: When the verbose level is set to `2` (`-vv`), the program will perform a diagnostic pass over the file system. This pass provides a clear breakdown of which files are included or excluded and the specific glob patterns responsible for the decision.
* **`processor.rs`**: The file processor now accepts the verbosity level. At `verbose` level `1` (`-v`), it will log each file it includes in the output. At both `1` and `2`, it will log when it skips a binary file.

### Usage

* `my-cli join -v`: Shows basic output, including which files are being included and skipped.
* `my-cli join -vv`: Provides a detailed, file-by-file log from the file walker, showing exactly why each file was included or excluded.